### PR TITLE
Add callback to update context menu items asynchronously on open.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9372,9 +9372,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.1.tgz",
-      "integrity": "sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     },
     "typescript-formatter": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "style-loader": "^0.13.2",
     "toolbox-loader": "0.0.3",
     "tslint": "^4.5.1",
-    "typescript": "^3.0.1",
+    "typescript": "^3.7.5",
     "typescript-formatter": "7.2.0",
     "webpack": "^1.13.1"
   }

--- a/src/columnspicker/content.spec.ts
+++ b/src/columnspicker/content.spec.ts
@@ -1,5 +1,5 @@
 import { Button, DialogActions, Select } from "@material-ui/core";
-import { configure, mount } from "enzyme";
+import { configure, mount, ReactWrapper } from "enzyme";
 import * as Adapter from "enzyme-adapter-react-16";
 import { createElement as __ } from "react";
 import AvailableColumns from "./availablecolumns";
@@ -107,7 +107,7 @@ describe("ColumnsPicker: ColumnsPickerContent", () => {
     it("Selecting/deselecting sets", () => {
         const props = testProps;
 
-        const component = mount(__(ColumnsPickerContent, props )as any);
+        const component = mount(__(ColumnsPickerContent, props) as any);
 
         expect(component.find(ColumnSetManager)).toHaveProp("currentSet", null);
 
@@ -167,7 +167,7 @@ describe("ColumnsPicker: ColumnsPickerContent", () => {
         const onSetsChangeSpy = spyOn(props, "onSetsChange");
         const onDoneSpy = spyOn(props, "onDone");
 
-        const component = mount(__(ColumnsPickerContent, props)as any);
+        const component = mount(__(ColumnsPickerContent, props) as any);
         component.find(ColumnSetManager).prop("onSelect")(columnSets[1]);
         component.update();
         expect(component.find(SortableColumns)).toHaveProp("columns", [
@@ -244,7 +244,7 @@ describe("ColumnsPicker: ColumnsPickerContent", () => {
         const onSetsChangeSpy = spyOn(props, "onSetsChange");
         const onDoneSpy = spyOn(props, "onDone");
 
-        const component = mount(__(ColumnsPickerContent, props)as any);
+        const component: ReactWrapper<ColumnsPickerContent["props"], ColumnsPickerContent["state"], ColumnsPickerContent> = mount(__(ColumnsPickerContent, props));
         component.find(ColumnSetManager).prop("onSelect")(component.state("sets")[1]);
         component.update();
         expect(component.find(SortableColumns)).toHaveProp("columns", [

--- a/src/doclist/RowMenu.spec.ts
+++ b/src/doclist/RowMenu.spec.ts
@@ -1,0 +1,94 @@
+import { configure, mount, shallow } from "enzyme";
+import * as Adapter from "enzyme-adapter-react-16";
+import * as jasmineEnzyme from "jasmine-enzyme";
+import { createElement } from "react";
+import { Fixture } from "../testUtils";
+import DynamicRowMenu, { RowMenu } from "./RowMenu";
+configure({ adapter: new Adapter() });
+
+describe("Doclist DynamicRowMenu", () => {
+    beforeEach(() => (<any>jasmineEnzyme)());
+
+    it("Renders row menu with passed parameters", () => {
+        const menuItems = [
+            {
+                key: "abc",
+                label: "xyz",
+                disabled: true,
+            },
+            {
+                key: "def",
+                label: "ghi",
+                disabled: false,
+            },
+        ];
+        const element = shallow(createElement(DynamicRowMenu, {
+            menuItems,
+            onMenuItemSelected: () => { },
+
+        }));
+
+        expect(element.find(RowMenu).length).toEqual(1);
+        expect(element.find(RowMenu).prop("menuItems")).toEqual(menuItems);
+        expect(element.find(RowMenu).prop("open")).toBe(false);
+
+    });
+
+    it("Renders the row menu and loads additional parameters when opened", async () => {
+        const menuItems = [
+            {
+                key: "abc",
+                label: "xyz",
+                disabled: true,
+            },
+            {
+                key: "def",
+                label: "ghi",
+                disabled: false,
+            },
+        ];
+        const promisesToAwait: Array<Promise<any>> = [];
+        const element = shallow(createElement(DynamicRowMenu, {
+            menuItems,
+            onMenuItemSelected: () => { },
+            onMenuLoadRequested: (callback) => {
+                const p: Promise<void> = new Promise((resolve) => {
+                    setTimeout(() => {
+                        callback(0, {
+                            key: "abc",
+                            label: "DDD",
+                            disabled: false,
+                        });
+                        resolve();
+                    }, 10);
+                });
+                promisesToAwait.push(p);
+                return p;
+            },
+        }));
+        // Trigger open of the menu
+        (element.find(RowMenu).prop("onRequestChange") as Function)(true);
+
+        // Menu should not be open yet
+        expect(element.find(RowMenu).prop("open")).toBe(false);
+
+        // Wait until promises have resolved
+        await Promise.all(promisesToAwait);
+
+        expect(element.find(RowMenu).prop("menuItems")).toEqual([
+            {
+                key: "abc",
+                label: "DDD",
+                disabled: false,
+            },
+            {
+                key: "def",
+                label: "ghi",
+                disabled: false,
+            },
+        ]);
+        expect(element.find(RowMenu).prop("open")).toBe(true);
+
+    });
+
+});

--- a/src/doclist/RowMenu.ts
+++ b/src/doclist/RowMenu.ts
@@ -1,0 +1,83 @@
+import { IconButton, IconMenu, MenuItem } from "material-ui";
+import MoreHorizIcon from "material-ui/svg-icons/navigation/more-horiz";
+import { createElement as __, MouseEvent, Component } from "react";
+type RowMenu_SharedProps_t<T> = {
+    menuItems: Array<MenuItem_t<T>>,
+    onMenuItemSelected: (menuKey: T, menuIndex: number) => void,
+};
+export type MenuItem_t<T> = {
+    key: T,
+    label: string,
+    disabled: boolean,
+};
+type RowMenu_Props_t<T> = RowMenu_SharedProps_t<T> & {
+    onRequestChange: (open: boolean) => void,
+    open: boolean,
+};
+export function RowMenu<T>({ menuItems, onMenuItemSelected, ...props }: RowMenu_Props_t<T>) {
+    return __(IconMenu, {
+        iconButtonElement: __(IconButton, { style: { padding: "0", height: "initial" }, disableTouchRipple: true }, __(MoreHorizIcon, { color: "grey" })),
+        targetOrigin: { horizontal: "right", vertical: "top" },
+        anchorOrigin: { horizontal: "right", vertical: "top" },
+        onRequestChange: props.onRequestChange,
+        open: props.open,
+    }, menuItems.map((mi, i) => __(MenuItem, {
+        key: i,
+        primaryText: mi.label,
+        disabled: mi.disabled,
+        onClick: (event: MouseEvent<any>) => {
+            onMenuItemSelected(mi.key, i);
+            event.stopPropagation();
+            event.preventDefault();
+        },
+    })));
+}
+
+type LoadMenuItem_Callback_t<T> = (index: number, menuItem: MenuItem_t<T>) => void;
+
+type DynamicRowMenu_Props_t<T> = RowMenu_SharedProps_t<T> & {
+    onMenuLoadRequested?: (callback: LoadMenuItem_Callback_t<T>) => void,
+};
+
+type DynamicRowMenu_State_t<T> = {
+    menuItems: Array<MenuItem_t<T>>,
+    open: boolean,
+};
+
+export default class DynamicRowMenu<T> extends Component<DynamicRowMenu_Props_t<T>, DynamicRowMenu_State_t<T>> {
+
+    constructor(props: DynamicRowMenu_Props_t<T>) {
+        super(props);
+        this.state = {
+            menuItems: [],
+            open: false,
+        };
+    }
+
+    private _triggerMenuLoad() {
+        if (!this.props.onMenuLoadRequested) {
+            return;
+        }
+        this.props.onMenuLoadRequested((newMenuIdx, newMenuItem) => {
+            this.setState((state) => ({
+                menuItems: state.menuItems.map((menuItem, menuIdx) => menuIdx === newMenuIdx ? newMenuItem : menuItem),
+            }));
+        });
+
+    }
+
+    public render() {
+        return __(RowMenu, {
+            open: this.state.open,
+            onRequestChange: (open: boolean) => {
+                this.setState({ open });
+                this._triggerMenuLoad();
+            },
+            menuItems: this.props.menuItems
+                .map((menuItem, menuIdx) => this.state.menuItems[menuIdx] || menuItem),
+            onMenuItemSelected: this.props.onMenuItemSelected,
+        });
+
+    }
+
+}

--- a/src/doclist/RowMenu.ts
+++ b/src/doclist/RowMenu.ts
@@ -59,9 +59,13 @@ export default class DynamicRowMenu<T> extends Component<DynamicRowMenu_Props_t<
             return;
         }
         this.props.onMenuLoadRequested((newMenuIdx, newMenuItem) => {
-            this.setState((state) => ({
-                menuItems: state.menuItems.map((menuItem, menuIdx) => menuIdx === newMenuIdx ? newMenuItem : menuItem),
-            }));
+            this.setState((state) => {
+                const newMenuItems = state.menuItems.slice();
+                newMenuItems[newMenuIdx] = newMenuItem;
+                return {
+                    menuItems: newMenuItems,
+                };
+            });
         });
 
     }
@@ -71,7 +75,9 @@ export default class DynamicRowMenu<T> extends Component<DynamicRowMenu_Props_t<
             open: this.state.open,
             onRequestChange: (open: boolean) => {
                 this.setState({ open });
-                this._triggerMenuLoad();
+                if (open) {
+                    this._triggerMenuLoad();
+                }
             },
             menuItems: this.props.menuItems
                 .map((menuItem, menuIdx) => this.state.menuItems[menuIdx] || menuItem),

--- a/src/doclist/nodetable.ts
+++ b/src/doclist/nodetable.ts
@@ -69,6 +69,7 @@ export interface INodeTableProps<T> {
     onRowSelected(node: Node_t, rowIndex: number): void; // Called when a row is selected
     onToggleAll?: (checked: boolean) => void;
     onRowToggled?: (node: Node_t, checked: boolean, rowIndex: number) => void;
+    onRowMenuOpened?: (node: Node_t) => void;
     onRowMenuItemClicked: OnMenuSelected_t<T>; // Called when a row menu item is selected
     onSortChanged: OnColumnSort_t; // Called when a column has to be sorted
 };
@@ -84,6 +85,9 @@ export function NodeTable<T>(props: INodeTableProps<T>) {
             width: 60,
             Cell: (prop: { value: INodeTableRow<T>, index: number }) => __(RowMenu, {
                 menuItems: prop.value.rowMenu,
+                onMenuOpened: () => {
+                    props.onRowMenuOpened && props.onRowMenuOpened(prop.value.node);
+                }
                 onMenuItemSelected: (menuKey: T, menuIndex: number) => {
                     props.onRowMenuItemClicked(prop.value.node, menuKey, prop.index, menuIndex);
                 },
@@ -204,16 +208,22 @@ function createColumn(col: INodeTableColumn): Column {
 }
 
 type RowMenu_Props_t<T> = {
-    menuItems: Array<MenuItem_t<T>>
+    menuItems: Array<MenuItem_t<T>>,
+    onMenuOpened: () => void,
     onMenuItemSelected: (menuKey: T, menuIndex: number) => void,
 };
 
-function RowMenu<T>({ menuItems, onMenuItemSelected }: RowMenu_Props_t<T>) {
+function RowMenu<T>({ menuItems, onMenuItemSelected, onMenuOpened }: RowMenu_Props_t<T>) {
     return __(IconMenu, {
         iconButtonElement: __(IconButton, { style: { padding: "0", height: "initial" }, disableTouchRipple: true },
             __(MoreHorizIcon, { color: "grey" })),
         targetOrigin: { horizontal: "right", vertical: "top" },
         anchorOrigin: { horizontal: "right", vertical: "top" },
+        onRequestChange: (open: boolean) => {
+            if (open) {
+                onMenuOpened();
+            }
+        }
     },
         menuItems.map((mi, i) =>
             __(MenuItem, {

--- a/src/doclist/nodetable.ts
+++ b/src/doclist/nodetable.ts
@@ -6,7 +6,7 @@ import "react-table/react-table.css";
 import { Node_t, FieldHighlights_t } from "../metadata";
 import { ColumnRenderer_t } from "./renderer/interface";
 import RowMenu, { MenuItem_t } from "./RowMenu";
-
+export { MenuItem_t as NodeTableRowMenuItem_t } from "./RowMenu";
 
 export interface INodeTableBasicColumn {
     name: string;

--- a/src/doclist/nodetable.ts
+++ b/src/doclist/nodetable.ts
@@ -1,17 +1,12 @@
-import { Checkbox, IconButton, IconMenu, MenuItem } from "material-ui";
-import MoreHorizIcon from "material-ui/svg-icons/navigation/more-horiz";
+import { Checkbox } from "material-ui";
 import ToggleIndeterminateCheckBox from "material-ui/svg-icons/toggle/indeterminate-check-box";
 import { createElement as __, CSSProperties, MouseEvent } from "react";
 import ReactTable, { Column, RowInfo, SortingRule, TableProps } from "react-table";
 import "react-table/react-table.css";
 import { Node_t, FieldHighlights_t } from "../metadata";
 import { ColumnRenderer_t } from "./renderer/interface";
+import RowMenu, { MenuItem_t } from "./RowMenu";
 
-type MenuItem_t<T> = {
-    key: T,
-    label: string,
-    disabled: boolean,
-};
 
 export interface INodeTableBasicColumn {
     name: string;
@@ -55,6 +50,7 @@ export interface INodeTableRow<T> {
     highlights?: FieldHighlights_t[];
 };
 
+type NodeTableMenuLoad_Callback_t<T> = (menuItemIndex: number, menuItem: MenuItem_t<T>) => void;
 export interface INodeTableProps<T> {
     rows: INodeTableRow<T>[]; // List of rows to show in the table
     columns: INodeTableColumn[]; // Columns to show in the table
@@ -69,7 +65,7 @@ export interface INodeTableProps<T> {
     onRowSelected(node: Node_t, rowIndex: number): void; // Called when a row is selected
     onToggleAll?: (checked: boolean) => void;
     onRowToggled?: (node: Node_t, checked: boolean, rowIndex: number) => void;
-    onRowMenuOpened?: (node: Node_t) => void;
+    onRowMenuLoadRequested?: (node: Node_t, rowIndex: number, callback: NodeTableMenuLoad_Callback_t<T>) => void;
     onRowMenuItemClicked: OnMenuSelected_t<T>; // Called when a row menu item is selected
     onSortChanged: OnColumnSort_t; // Called when a column has to be sorted
 };
@@ -85,9 +81,11 @@ export function NodeTable<T>(props: INodeTableProps<T>) {
             width: 60,
             Cell: (prop: { value: INodeTableRow<T>, index: number }) => __(RowMenu, {
                 menuItems: prop.value.rowMenu,
-                onMenuOpened: () => {
-                    props.onRowMenuOpened && props.onRowMenuOpened(prop.value.node);
-                }
+                onMenuLoadRequested: (callback) => {
+                    if (props.onRowMenuLoadRequested) {
+                        props.onRowMenuLoadRequested(prop.value.node, prop.index, callback);
+                    }
+                },
                 onMenuItemSelected: (menuKey: T, menuIndex: number) => {
                     props.onRowMenuItemClicked(prop.value.node, menuKey, prop.index, menuIndex);
                 },
@@ -205,37 +203,4 @@ function createColumn(col: INodeTableColumn): Column {
             highlights: prop.value.highlights || [],
         }),
     };
-}
-
-type RowMenu_Props_t<T> = {
-    menuItems: Array<MenuItem_t<T>>,
-    onMenuOpened: () => void,
-    onMenuItemSelected: (menuKey: T, menuIndex: number) => void,
-};
-
-function RowMenu<T>({ menuItems, onMenuItemSelected, onMenuOpened }: RowMenu_Props_t<T>) {
-    return __(IconMenu, {
-        iconButtonElement: __(IconButton, { style: { padding: "0", height: "initial" }, disableTouchRipple: true },
-            __(MoreHorizIcon, { color: "grey" })),
-        targetOrigin: { horizontal: "right", vertical: "top" },
-        anchorOrigin: { horizontal: "right", vertical: "top" },
-        onRequestChange: (open: boolean) => {
-            if (open) {
-                onMenuOpened();
-            }
-        }
-    },
-        menuItems.map((mi, i) =>
-            __(MenuItem, {
-                key: i,
-                primaryText: mi.label,
-                disabled: mi.disabled,
-                onClick: (event: MouseEvent<any>) => {
-                    onMenuItemSelected(mi.key, i);
-                    event.stopPropagation();
-                    event.preventDefault();
-                },
-            }),
-        ),
-    );
 }

--- a/src/doclist/nodetable.ts
+++ b/src/doclist/nodetable.ts
@@ -65,7 +65,7 @@ export interface INodeTableProps<T> {
     onRowSelected(node: Node_t, rowIndex: number): void; // Called when a row is selected
     onToggleAll?: (checked: boolean) => void;
     onRowToggled?: (node: Node_t, checked: boolean, rowIndex: number) => void;
-    onRowMenuLoadRequested?: (node: Node_t, rowIndex: number, callback: NodeTableMenuLoad_Callback_t<T>) => void;
+    onRowMenuLoadRequested?: (node: Node_t, rowIndex: number, callback: NodeTableMenuLoad_Callback_t<T>) => Promise<void>;
     onRowMenuItemClicked: OnMenuSelected_t<T>; // Called when a row menu item is selected
     onSortChanged: OnColumnSort_t; // Called when a column has to be sorted
 };
@@ -83,8 +83,9 @@ export function NodeTable<T>(props: INodeTableProps<T>) {
                 menuItems: prop.value.rowMenu,
                 onMenuLoadRequested: (callback) => {
                     if (props.onRowMenuLoadRequested) {
-                        props.onRowMenuLoadRequested(prop.value.node, prop.index, callback);
+                        return props.onRowMenuLoadRequested(prop.value.node, prop.index, callback);
                     }
+                    return Promise.resolve();
                 },
                 onMenuItemSelected: (menuKey: T, menuIndex: number) => {
                     props.onRowMenuItemClicked(prop.value.node, menuKey, prop.index, menuIndex);


### PR DESCRIPTION
The menu starts with all items passed in `menuItems`, but can then be updated from the `onMenuLoadRequested` callback.