### PR TITLE
[XENFIN-1291] Only keep autocomplete backdrop mounted when it is visible

### DIFF
--- a/src/searchbar/autocomplete/AutocompletePaper.tsx
+++ b/src/searchbar/autocomplete/AutocompletePaper.tsx
@@ -102,7 +102,7 @@ function AutocompletePaper(props: AutocompletePaper_Props_t & WithStyles<typeof 
             },
         }} />
         <div className={props.classes.root} ref={rootElem}>
-            <Backdrop open={props.open} classes={{ root: props.classes.backdrop }} onClick={onDismiss} />
+            <Backdrop open={props.open} classes={{ root: props.classes.backdrop }} onClick={onDismiss} mountOnEnter unmountOnExit />
             <DivWithSize className={props.classes.target} ref={(e: any) => setTargetElem(findDOMNode(e) as HTMLDivElement)} onSize={({ width }) => {
                 setAutocompleteWidth(width ?? undefined);
             }}>


### PR DESCRIPTION
When <Backdrop open={false}>, but it is not unmounted, it still covers
the whole page with its backdrop element that is still mounted.
Unmounting it automatically when it is no longer opened and after its
closing transition has disappeared will ensure that the backdrop element
is not on the page anymore.