### PR TITLE
XENFIN-1392: Allow custom format for string properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,15 @@ Template:
 ### Fixed
 ### Security
 
-docker run --rm -v "$(pwd):/manual" -w /manual hub.xenit.eu/private/xenit-markdowntopdf:latest --output Alfred_Finder_UI_CHANGELOG.pdf CHANGELOG.md
+docker run --rm -v "$(pwd):/manual" -w /manual private.docker.xenit.eu/xenit-markdowntopdf:latest --output Alfred_Finder_UI_CHANGELOG.pdf CHANGELOG.md
 -->
 
 # Alfred Finder - UI - Changelog
+
+## 2.6.0 (2024-04-04)
+
+### Added
+* [XENFIN-1392](https://xenitsupport.jira.com/browse/XENFIN-1392): Allow custom format for string properties
 
 ## 2.5.8 (2024-02-15)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xenit/finder-ui",
-  "version": "2.5.8",
+  "version": "2.6.0",
   "description": "Finder UI components using ReactJS (based on material-ui.com)",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/doclist/renderer/property.ts
+++ b/src/doclist/renderer/property.ts
@@ -23,7 +23,9 @@ export default PropertyRenderer;
 /*We can use the metadata renderers of the metadata panel here instead of this function*/
 function convertToString(parameters: { [k: string]: any }, value: Property_t) {
     if (typeof value === "string") {
-        return value;
+        const pattern = parameters["string-pattern"];
+        const format = parameters["string-format"];
+        return (pattern && format) ? value.replace(new RegExp(pattern), format) : value;
     }
 
     if (typeof value === "boolean") {

--- a/src/metadata/property/label.ts
+++ b/src/metadata/property/label.ts
@@ -56,7 +56,11 @@ const Label: PropertyRenderer_t<string | string[]> = (config: PropertyRenderConf
             if (!this.state.currentValuesLoaded) {
                 return _.span(classNamed, "Loading...");
             }
-            const values = this.state.currentValues.map((item) => item.value);
+            const pattern = config.parameters["string-pattern"];
+            const format = config.parameters["string-format"];
+            const values = (pattern && format)
+                ? this.state.currentValues.map((item) => item.value.replace(new RegExp(pattern), format))
+                : this.state.currentValues.map((item) => item.value);
             const value = values.join(", ");
             if (value.startsWith("icon-")) {
                 const iconProps = this.getIconProps(value.substring(5));


### PR DESCRIPTION
Format to be provided in the forms config as a regex and a replacement string, eg:
```
string-pattern: ^(\d{2})(\d{2})(\d{2})(\d{3})(\d{2})$
string-format: $1.$2.$3-$4.$5
```